### PR TITLE
fix(Revm): remove CodeType assumption

### DIFF
--- a/externals/revm_fzz/src/lib.rs
+++ b/externals/revm_fzz/src/lib.rs
@@ -1,10 +1,11 @@
+use revm_interpreter::{analysis::validate_raw_eof_inner, primitives::Bytes};
+
 #[no_mangle]
 pub extern "C" fn fzz_revm_validate_eof(data: *const u8, len: usize) -> bool {
     let slice = unsafe { std::slice::from_raw_parts(data, len) };
-    let b = revm_interpreter::primitives::Bytes::from(slice);
-    let r = revm_interpreter::analysis::validate_raw_eof(b);
+    let r = validate_raw_eof_inner(Bytes::from(slice), None);
     match r {
         Ok(_) => true,
-        Err(_) => false
+        Err(_) => false,
     }
 }


### PR DESCRIPTION
This removes assumptions about code type (container kind). 

Noticed here: https://github.com/ipsilon/eof/issues/146#issuecomment-2248966592